### PR TITLE
Fixed Flaky Test

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -99,9 +99,9 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     
     try {
       ObjectMapper mapper = new ObjectMapper();
-      JsonNode node1 = mapper.readTree(FLAT_JSON);
-      JsonNode node2 = mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
-      Assert.assertTrue(TestUtil.compareJsonObjects(node1, node2));
+      JsonNode flatJsonNode = mapper.readTree(FLAT_JSON);
+      JsonNode sampledJsonNode = mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+      Assert.assertTrue(TestUtil.compareJsonObjects(flatJsonNode, sampledJsonNode));
     } 
     catch (IOException e) {
       Assert.fail("Failed Json Assert");
@@ -138,7 +138,16 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         JSONPathSpec.DEFAULT
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode flatJsonNode = mapper.readTree(FLAT_JSON);
+      JsonNode sampledJsonNode = mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+      Assert.assertTrue(TestUtil.compareJsonObjects(flatJsonNode, sampledJsonNode));
+    } 
+    catch (IOException e) {
+      Assert.fail("Failed Json Assert");
+    }
   }
 
   @Test
@@ -179,7 +188,16 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode flatJsonNode = mapper.readTree(FLAT_JSON);
+      JsonNode sampledJsonNode = mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+      Assert.assertTrue(TestUtil.compareJsonObjects(flatJsonNode, sampledJsonNode));
+    } 
+    catch (IOException e) {
+      Assert.fail("Failed Json Assert");
+    }
   }
 
   @Test
@@ -218,7 +236,15 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
 
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode flatJsonNode = mapper.readTree(FLAT_JSON);
+      JsonNode sampledJsonNode = mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+      Assert.assertTrue(TestUtil.compareJsonObjects(flatJsonNode, sampledJsonNode));
+    } 
+    catch (IOException e) {
+      Assert.fail("Failed Json Assert");
+    }
   }
 
 
@@ -255,7 +281,16 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode nestedJsonNode = mapper.readTree(NESTED_JSON);
+      JsonNode sampledJsonNode = mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+      Assert.assertTrue(TestUtil.compareJsonObjects(nestedJsonNode, sampledJsonNode));
+    } 
+    catch (IOException e) {
+      Assert.fail("Failed Json Assert");
+    }
   }
 
   @Test
@@ -288,7 +323,16 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         JSONPathSpec.DEFAULT
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode nestedJsonNode = mapper.readTree(NESTED_JSON);
+      JsonNode sampledJsonNode = mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+      Assert.assertTrue(TestUtil.compareJsonObjects(nestedJsonNode, sampledJsonNode));
+    } 
+    catch (IOException e) {
+      Assert.fail("Failed Json Assert");
+    }
   }
 
   @Test
@@ -331,7 +375,16 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode nestedJsonNode = mapper.readTree(NESTED_JSON);
+      JsonNode sampledJsonNode = mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+      Assert.assertTrue(TestUtil.compareJsonObjects(nestedJsonNode, sampledJsonNode));
+    } 
+    catch (IOException e) {
+      Assert.fail("Failed Json Assert");
+    }
   }
 
   @Test
@@ -372,7 +425,16 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode nestedJsonNode = mapper.readTree(NESTED_JSON);
+      JsonNode sampledJsonNode = mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+      Assert.assertTrue(TestUtil.compareJsonObjects(nestedJsonNode, sampledJsonNode));
+    } 
+    catch (IOException e) {
+      Assert.fail("Failed Json Assert");
+    }
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -27,6 +29,7 @@ import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.data.input.parquet.util.TestUtil;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
@@ -93,7 +96,16 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode node1 = mapper.readTree(FLAT_JSON);
+      JsonNode node2 = mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+      Assert.assertTrue(TestUtil.compareJsonObjects(node1, node2));
+    } 
+    catch (IOException e) {
+      Assert.fail("Failed Json Assert");
+    }
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/util/TestUtil.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/util/TestUtil.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.parquet.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class TestUtil 
+{
+  public static boolean compareJsonObjects(JsonNode node1, JsonNode node2) 
+  {
+    if (node1.equals(node2)) {
+      return true;
+    }
+
+    if (node1.isObject() && node2.isObject()) {
+      Map<String, JsonNode> map1 = new ObjectMapper().convertValue(node1, Map.class);
+      Map<String, JsonNode> map2 = new ObjectMapper().convertValue(node2, Map.class);
+
+      return compareMaps(map1, map2);
+    }
+
+    if (node1.isArray() && node2.isArray()) {
+      List<JsonNode> list1 = new ObjectMapper().convertValue(node1, ArrayList.class);
+      List<JsonNode> list2 = new ObjectMapper().convertValue(node2, ArrayList.class);
+
+      return compareLists(list1, list2);
+    }
+
+    return false;
+  }
+
+  public static boolean compareMaps(Map<String, JsonNode> map1, Map<String, JsonNode> map2) 
+  {
+    if (map1.size() != map2.size()) {
+      return false;
+    }
+
+    for (Map.Entry<String, JsonNode> entry : map1.entrySet()) {
+      if (!map2.containsKey(entry.getKey())) {
+        return false;
+      }
+
+      if (!compareJsonObjects(entry.getValue(), map2.get(entry.getKey()))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public static boolean compareLists(List<JsonNode> list1, List<JsonNode> list2) 
+  {
+    if (list1.size() != list2.size()) {
+      return false;
+    }
+
+    List<JsonNode> sortedList1 = new ArrayList<>(list1);
+    List<JsonNode> sortedList2 = new ArrayList<>(list2);
+
+    Collections.sort(sortedList1, (x, y) -> compareJsonObjects(x, y) ? 0 : -1);
+    Collections.sort(sortedList2, (x, y) -> compareJsonObjects(x, y) ? 0 : -1);
+
+    for (int i = 0; i < sortedList1.size(); i++) {
+      if (!compareJsonObjects(sortedList1.get(i), sortedList2.get(i))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+} 

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/util/TestUtil.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/util/TestUtil.java
@@ -29,6 +29,8 @@ import java.util.Map;
 
 public class TestUtil 
 {
+  // Compares two JsonNode objects for equivalence.
+  // This method is recursive and can handle nested JSON objects and arrays.
   public static boolean compareJsonObjects(JsonNode node1, JsonNode node2) 
   {
     if (node1.equals(node2)) {


### PR DESCRIPTION
### Description
Fixed the test as it was reported as flaky by the NonDex tool. The assertion fails due to inconsistency in the ordering of keys and values within the JSON structure leading to different output sequences in each test run.

**Reproduce the failure**
One can check it using the [Nondex](https://github.com/TestingResearchIllinois/nondex):

mvn install -DskipTests
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1NoFlattenSpec

### Solution 

#### Fixed the bug 
I had considered the alternative of using the JSONassert library that compares the two JSON strings as it forgives reordering data, making tests less brittle. I didn't follow through as I would have to add dependencies which is not recommended.

I had looked into the JSON Parsers implemented by Druid but they didn't have anything on comparing two JSON Strings. Since the project was already using **Class JsonNode**, I reused this class and wrote a custom utility method to compare the two JSON nodes for equality.

This PR has:

- [x ] been self-reviewed.
- [x ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
